### PR TITLE
Fix alignment of models in the scene

### DIFF
--- a/generate_scene_obj.py
+++ b/generate_scene_obj.py
@@ -94,6 +94,11 @@ if __name__ == '__main__':
                     y = float(s[1])
                     z = float(s[2])
                     p = numpy.array([x,y,z])
+
+                    tmp = p[0]
+                    p[0] = p[2]
+                    p[2] = -tmp
+
                     p = (p - centroid) * (height / (bb[3] - bb[2]))
                     p = R.dot(p) + T
                     output_file.write('v %f %f %f\n' % (p[0],p[1],p[2]))


### PR DESCRIPTION
There's a mismatch between the complete scenes generated with the current _generate_scene_obj.py_ code and the rendered RGBD images of the same scene. 

Take scene val/0/942 (trajectory 2 from the validation set), this is the RGB rendering 6250.jpg:

![6250](https://user-images.githubusercontent.com/2853614/37153225-4b17538e-22dc-11e8-8fe0-14b84385333d.jpg)

And this is a screenshot of the rendered _complete_scene.obj_ for the same scene using the current code in _generate_scene_obj.py_:

![master](https://user-images.githubusercontent.com/2853614/37153423-f4564e32-22dc-11e8-839c-96b465362158.png)

You can see that the x and y axes of the objects in the scene are misaligned between the two images. The reason is just a different assumption about the alignment of the models between the ShapeNet dataset and SceneNet code.

With this patch the result is instead:

![pr](https://user-images.githubusercontent.com/2853614/37153473-20297e6c-22dd-11e8-8184-ebc714943a07.png)

which matches the RGB rendering from above.

